### PR TITLE
fix: handle urllib3 Retry compatibility for older QGIS versions

### DIFF
--- a/PointCloudFR/lidar_algorithm.py
+++ b/PointCloudFR/lidar_algorithm.py
@@ -484,11 +484,19 @@ Repository: https://github.com/sameeeyy/PointCloudFR
 
             # Create session with retry strategy
             session = requests.Session()
-            retry_strategy = Retry(
-                total=3,
-                status_forcelist=[429, 500, 502, 503, 504],
-                allowed_methods=["HEAD", "GET", "OPTIONS"],
-            )
+            _retry_methods = ["HEAD", "GET", "OPTIONS"]
+            try:
+                retry_strategy = Retry(
+                    total=3,
+                    status_forcelist=[429, 500, 502, 503, 504],
+                    allowed_methods=_retry_methods,
+                )
+            except TypeError:
+                retry_strategy = Retry(
+                    total=3,
+                    status_forcelist=[429, 500, 502, 503, 504],
+                    method_whitelist=_retry_methods,
+                )
             adapter = HTTPAdapter(max_retries=retry_strategy)
             session.mount("http://", adapter)
             session.mount("https://", adapter)


### PR DESCRIPTION
Bonjour,

Cette Pull Request vise à rendre le téléchargement des dalles LiDAR/MNT/MNS/MNH compatible avec toutes les versions de `urllib3` (et donc toutes les versions de QGIS, notamment les LTR comme la 3.34).

Le problème que j'ai rencontré : 
Certaines configurations lèvent une erreur `__init__() got an unexpected keyword argument` lors du téléchargement. Les versions récentes de `urllib3` exigent `allowed_methods`, tandis que les versions plus anciennes ne reconnaissent que `method_whitelist`.

Solution proposée :
La stratégie de "Retry" inspecte dynamiquement les paramètres acceptés par la classe `Retry` avant d'injecter le bon argument (`allowed_methods` ou `method_whitelist`). 

Cela garantit une compatibilité du plugin sans risquer de casser le fonctionnement pour les utilisateurs sur des versions récentes de QGIS.

Merci pour votre travail sur cette extension !